### PR TITLE
Update goreleaser

### DIFF
--- a/.gon-arm64.json
+++ b/.gon-arm64.json
@@ -1,5 +1,5 @@
 {
-  "source": ["./dist/macos-arm64_darwin_arm64/baton-datadog"],
+  "source": ["./dist/macos-arm64_darwin_arm64_v8.0/baton-datadog"],
   "bundle_id": "com.conductorone.baton-datadog",
   "apple_id": {
     "username" : "justin.gallardo@conductorone.com"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ builds:
     hooks:
       post:
         - gon .gon-arm64.json
-        - mv dist/baton-datadog-darwin-arm64.signed.zip dist/macos-arm64_darwin_arm64/baton-datadog
+        - mv dist/baton-datadog-darwin-arm64.signed.zip dist/macos-arm64_darwin_arm64_v8.0/baton-datadog
 archives:
   - id: linux-archive
     builds:


### PR DESCRIPTION
Fixes this failed release: https://github.com/ConductorOne/baton-datadog/actions/runs/14984211282/job/42095390114