### PR TITLE
Add nil guards to apiToken fields

### DIFF
--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -53,13 +53,11 @@ func (o *apiTokenBuilder) List(
 	ret := make([]*v2.Resource, 0, len(apiTokens))
 	for _, apiToken := range apiTokens {
 		// Check required fields before any dereferencing
-		if apiToken.Id == nil || apiToken.Attributes == nil ||
-			apiToken.Attributes.CreatedAt == nil || apiToken.Attributes.ModifiedAt == nil ||
+		if apiToken.Id == nil ||
 			apiToken.Relationships == nil || apiToken.Relationships.CreatedBy == nil {
 			l := ctxzap.Extract(ctx)
 			l.Warn("skipping API token with missing required fields",
 				zap.Bool("has_id", apiToken.Id != nil),
-				zap.Bool("has_attributes", apiToken.Attributes != nil),
 				zap.Bool("has_relationships", apiToken.Relationships != nil),
 			)
 			continue
@@ -67,25 +65,30 @@ func (o *apiTokenBuilder) List(
 
 		userId := apiToken.Relationships.CreatedBy.Data.Id
 		timeFormat := time.RFC3339Nano
-		createdAt, err := time.Parse(timeFormat, *apiToken.Attributes.CreatedAt)
-		if err != nil {
-			return nil, "", nil, err
-		}
-		modifiedAt, err := time.Parse(timeFormat, *apiToken.Attributes.ModifiedAt)
-		if err != nil {
-			return nil, "", nil, err
-		}
 		options := []resource.SecretTraitOption{
 			resource.WithSecretCreatedByID(&v2.ResourceId{
 				ResourceType:  userResourceType.Id,
 				Resource:      userId,
 				BatonResource: false,
 			}),
-			resource.WithSecretLastUsedAt(modifiedAt),
-			resource.WithSecretCreatedAt(createdAt),
+		}
+
+		if apiToken.Attributes != nil && apiToken.Attributes.CreatedAt != nil {
+			createdAt, err := time.Parse(timeFormat, *apiToken.Attributes.CreatedAt)
+			if err != nil {
+				return nil, "", nil, err
+			}
+			options = append(options, resource.WithSecretCreatedAt(createdAt))
+		}
+		if apiToken.Attributes != nil && apiToken.Attributes.ModifiedAt != nil {
+			modifiedAt, err := time.Parse(timeFormat, *apiToken.Attributes.ModifiedAt)
+			if err != nil {
+				return nil, "", nil, err
+			}
+			options = append(options, resource.WithSecretLastUsedAt(modifiedAt))
 		}
 		name := *apiToken.Id
-		if apiToken.Attributes.Name != nil {
+		if apiToken.Attributes != nil && apiToken.Attributes.Name != nil {
 			name = *apiToken.Attributes.Name
 		}
 		rv, err := resource.NewSecretResource(

--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -11,6 +11,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type apiTokenBuilder struct {
@@ -50,6 +52,19 @@ func (o *apiTokenBuilder) List(
 	apiTokens := res.GetData()
 	ret := make([]*v2.Resource, 0, len(apiTokens))
 	for _, apiToken := range apiTokens {
+		// Check required fields before any dereferencing
+		if apiToken.Id == nil || apiToken.Attributes == nil ||
+			apiToken.Attributes.CreatedAt == nil || apiToken.Attributes.ModifiedAt == nil ||
+			apiToken.Relationships == nil || apiToken.Relationships.CreatedBy == nil {
+			l := ctxzap.Extract(ctx)
+			l.Warn("skipping API token with missing required fields",
+				zap.Bool("has_id", apiToken.Id != nil),
+				zap.Bool("has_attributes", apiToken.Attributes != nil),
+				zap.Bool("has_relationships", apiToken.Relationships != nil),
+			)
+			continue
+		}
+
 		userId := apiToken.Relationships.CreatedBy.Data.Id
 		timeFormat := time.RFC3339Nano
 		createdAt, err := time.Parse(timeFormat, *apiToken.Attributes.CreatedAt)
@@ -69,8 +84,12 @@ func (o *apiTokenBuilder) List(
 			resource.WithSecretLastUsedAt(modifiedAt),
 			resource.WithSecretCreatedAt(createdAt),
 		}
+		name := ""
+		if apiToken.Attributes.Name != nil {
+			name = *apiToken.Attributes.Name
+		}
 		rv, err := resource.NewSecretResource(
-			*apiToken.Attributes.Name,
+			name,
 			apiTokenResourceType,
 			*apiToken.Id,
 			options,

--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -52,27 +52,25 @@ func (o *apiTokenBuilder) List(
 	apiTokens := res.GetData()
 	ret := make([]*v2.Resource, 0, len(apiTokens))
 	for _, apiToken := range apiTokens {
-		// Check required fields before any dereferencing
-		if apiToken.Id == nil ||
-			apiToken.Relationships == nil || apiToken.Relationships.CreatedBy == nil {
+		if apiToken.Id == nil {
 			l := ctxzap.Extract(ctx)
 			l.Warn("skipping API token with missing required fields",
 				zap.Bool("has_id", apiToken.Id != nil),
-				zap.Bool("has_relationships", apiToken.Relationships != nil),
 			)
 			continue
 		}
 
-		userId := apiToken.Relationships.CreatedBy.Data.Id
-		timeFormat := time.RFC3339Nano
-		options := []resource.SecretTraitOption{
-			resource.WithSecretCreatedByID(&v2.ResourceId{
+		options := []resource.SecretTraitOption{}
+		if apiToken.Relationships != nil && apiToken.Relationships.CreatedBy != nil {
+			userId := apiToken.Relationships.CreatedBy.Data.Id
+			options = append(options, resource.WithSecretCreatedByID(&v2.ResourceId{
 				ResourceType:  userResourceType.Id,
 				Resource:      userId,
 				BatonResource: false,
-			}),
+			}))
 		}
 
+		timeFormat := time.RFC3339Nano
 		if apiToken.Attributes != nil && apiToken.Attributes.CreatedAt != nil {
 			createdAt, err := time.Parse(timeFormat, *apiToken.Attributes.CreatedAt)
 			if err != nil {

--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -84,7 +84,7 @@ func (o *apiTokenBuilder) List(
 			resource.WithSecretLastUsedAt(modifiedAt),
 			resource.WithSecretCreatedAt(createdAt),
 		}
-		name := ""
+		name := *apiToken.Id
 		if apiToken.Attributes.Name != nil {
 			name = *apiToken.Attributes.Name
 		}


### PR DESCRIPTION
We saw a nil pointer exception dereferencing `apiToken.Attributes.Name`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip incomplete or malformed API tokens during listing to avoid errors.
  * Preserve and surface token names when available; default sensibly when missing.
  * Safer handling of creation/modified timestamps to prevent parse failures if fields are absent.
  * Improved diagnostic logging that reports which token fields are missing to aid troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->