### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-datadog/main.go
+++ b/cmd/baton-datadog/main.go
@@ -50,6 +50,7 @@ func getConnector(ctx context.Context, ddc *cfg.Datadog) (types.ConnectorServer,
 		ddc.Site,
 		ddc.ApiKey,
 		ddc.AppKey,
+		ddc.BaseUrl,
 		ddc.SyncSecrets,
 		ddc.SyncSchedules,
 	)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -165,7 +165,7 @@ func TestNewDatadogRestClient(t *testing.T) {
 	apiKey := testAPIKey
 	appKey := testAppKey
 
-	client, err := NewDatadogRestClient(context.Background(), site, apiKey, appKey)
+	client, err := NewDatadogRestClient(context.Background(), site, apiKey, appKey, "")
 	assertNoError(t, err, "should not return error")
 
 	assertNotNil(t, client, "client should not be nil")
@@ -482,7 +482,7 @@ func TestDatadogRestClient_OnCallMethods(t *testing.T) {
 	apiKey := testAPIKey
 	appKey := testAppKey
 
-	client, err := NewDatadogRestClient(context.Background(), site, apiKey, appKey)
+	client, err := NewDatadogRestClient(context.Background(), site, apiKey, appKey, "")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -155,9 +155,11 @@ func (c *TestClient) GetScheduleOnCallUser(ctx context.Context, scheduleID strin
 
 // Constants for test data.
 const (
-	testScheduleID = "schedule-1"
-	testAPIKey     = "test-api-key"
-	testAppKey     = "test-app-key"
+	testScheduleID  = "schedule-1"
+	testAPIKey      = "test-api-key"
+	testAppKey      = "test-app-key"
+	testOncallType  = "oncall_schedule"
+	testTimezoneUTC = "UTC"
 )
 
 func TestNewDatadogRestClient(t *testing.T) {
@@ -169,7 +171,8 @@ func TestNewDatadogRestClient(t *testing.T) {
 	assertNoError(t, err, "should not return error")
 
 	assertNotNil(t, client, "client should not be nil")
-	assertEqual(t, site, client.site, "site should match")
+	expectedBaseURL := fmt.Sprintf(DefaultBaseURL, site)
+	assertEqual(t, expectedBaseURL, client.baseURL, "baseURL should match")
 	assertEqual(t, apiKey, client.apiKey, "apiKey should match")
 	assertEqual(t, appKey, client.appKey, "appKey should match")
 	assertNotNil(t, client.httpClient, "httpClient should not be nil")
@@ -183,16 +186,16 @@ func TestListOnCallSchedules_Success(t *testing.T) {
 	mockResponse := OnCallSchedulesResponse{
 		Data: []*OnCallSchedule{
 			{
-				ID:   "schedule-1",
-				Type: "oncall_schedule",
+				ID:   testScheduleID,
+				Type: testOncallType,
 				Attributes: OnCallScheduleAttributes{
 					Name:     "Primary On-Call",
-					TimeZone: "UTC",
+					TimeZone: testTimezoneUTC,
 				},
 			},
 			{
 				ID:   "schedule-2",
-				Type: "oncall_schedule",
+				Type: testOncallType,
 				Attributes: OnCallScheduleAttributes{
 					Name:     "Secondary On-Call",
 					TimeZone: "America/New_York",
@@ -265,7 +268,7 @@ func TestListOnCallSchedules_Success(t *testing.T) {
 	assertNoError(t, err, "should not return error")
 	assertNotNil(t, result, "result should not be nil")
 	assertEqualInt(t, 2, len(result.Data), "should have 2 schedules")
-	assertEqual(t, "schedule-1", result.Data[0].ID, "first schedule ID should match")
+	assertEqual(t, testScheduleID, result.Data[0].ID, "first schedule ID should match")
 	assertEqual(t, "Primary On-Call", result.Data[0].Attributes.Name, "first schedule name should match")
 	assertEqual(t, "schedule-2", result.Data[1].ID, "second schedule ID should match")
 	assertEqual(t, "Secondary On-Call", result.Data[1].Attributes.Name, "second schedule name should match")

--- a/pkg/client/pagination_test.go
+++ b/pkg/client/pagination_test.go
@@ -93,16 +93,16 @@ func TestListOnCallSchedulesPaginated_WithPagination(t *testing.T) {
 	mockResponse := OnCallSchedulesResponse{
 		Data: []*OnCallSchedule{
 			{
-				ID:   "schedule-1",
-				Type: "oncall_schedule",
+				ID:   testScheduleID,
+				Type: testOncallType,
 				Attributes: OnCallScheduleAttributes{
 					Name:     "Primary On-Call",
-					TimeZone: "UTC",
+					TimeZone: testTimezoneUTC,
 				},
 			},
 			{
 				ID:   "schedule-2",
-				Type: "oncall_schedule",
+				Type: testOncallType,
 				Attributes: OnCallScheduleAttributes{
 					Name:     "Secondary On-Call",
 					TimeZone: "America/New_York",
@@ -247,11 +247,11 @@ func TestListOnCallSchedulesPaginated_DefaultOptions(t *testing.T) {
 	mockResponse := OnCallSchedulesResponse{
 		Data: []*OnCallSchedule{
 			{
-				ID:   "schedule-1",
-				Type: "oncall_schedule",
+				ID:   testScheduleID,
+				Type: testOncallType,
 				Attributes: OnCallScheduleAttributes{
 					Name:     "Test Schedule",
-					TimeZone: "UTC",
+					TimeZone: testTimezoneUTC,
 				},
 			},
 		},

--- a/pkg/client/rest_client.go
+++ b/pkg/client/rest_client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	datadogAPIBaseURL       = "https://api.%s"
+	DefaultBaseURL          = "https://api.%s"
 	OnCallSchedulesEndpoint = "/api/v2/on-call/schedules"
 	OnCallUserEndpoint      = "/api/v2/on-call/schedules/%s/on-call"
 
@@ -66,7 +66,7 @@ func (d *datadogErrorResponse) Message() string {
 // that is not available in the official client library.
 type DatadogRestClient struct {
 	httpClient *uhttp.BaseHttpClient
-	site       string
+	baseURL    string
 	apiKey     string
 	appKey     string
 }
@@ -81,7 +81,8 @@ type DatadogClientInterface interface {
 var _ DatadogClientInterface = (*DatadogRestClient)(nil)
 
 // NewDatadogRestClient creates a new instance of the REST client.
-func NewDatadogRestClient(ctx context.Context, site string, apiKey string, appKey string) (*DatadogRestClient, error) {
+// If baseURL is empty, it will be constructed from site using DefaultBaseURL.
+func NewDatadogRestClient(ctx context.Context, site string, apiKey string, appKey string, baseURL string) (*DatadogRestClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
@@ -92,9 +93,15 @@ func NewDatadogRestClient(ctx context.Context, site string, apiKey string, appKe
 		return nil, err
 	}
 
+	// Use provided baseURL or construct from site
+	effectiveBaseURL := baseURL
+	if effectiveBaseURL == "" {
+		effectiveBaseURL = fmt.Sprintf(DefaultBaseURL, site)
+	}
+
 	return &DatadogRestClient{
 		httpClient: uhttpClient,
-		site:       site,
+		baseURL:    effectiveBaseURL,
 		apiKey:     apiKey,
 		appKey:     appKey,
 	}, nil
@@ -109,7 +116,7 @@ func (c *DatadogRestClient) doRequest(
 	result interface{},
 	opts ...ReqOpt,
 ) (annotations.Annotations, error) {
-	baseUrl, err := url.Parse(fmt.Sprintf(datadogAPIBaseURL, c.site))
+	baseUrl, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -9,6 +9,7 @@ type Datadog struct {
 	AppKey string `mapstructure:"app-key"`
 	SyncSecrets bool `mapstructure:"sync-secrets"`
 	SyncSchedules bool `mapstructure:"sync-schedules"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Datadog) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,7 @@ var (
 		field.WithDescription("Override the Datadog API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Datadog API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,11 @@ var (
 		field.WithDefaultValue(false),
 		field.WithDisplayName("Sync schedules"),
 	)
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Datadog API URL (for testing)"),
+		field.WithDisplayName("Base URL"),
+	)
 
 	// FieldRelationships defines relationships between the fields listed in
 	// Config that can be automatically validated. For example, a
@@ -51,6 +56,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	AppKey,
 	SyncSecrets,
 	SyncSchedules,
+	BaseURL,
 })
 
 // ValidateConfig is run after the configuration is loaded, and should return an

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -19,6 +19,7 @@ type Datadog struct {
 	site          string
 	apiKey        string
 	appKey        string
+	baseURL       string
 	syncSecrets   bool
 	syncSchedules bool
 }
@@ -112,7 +113,7 @@ func (d *Datadog) Validate(ctx context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, site, apiKey, appKey string, syncSecrets, syncSchedules bool) (*Datadog, error) {
+func New(ctx context.Context, site, apiKey, appKey, baseURL string, syncSecrets, syncSchedules bool) (*Datadog, error) {
 	// Validate input parameters
 	if site == "" {
 		return nil, fmt.Errorf("site cannot be empty")
@@ -132,8 +133,17 @@ func New(ctx context.Context, site, apiKey, appKey string, syncSecrets, syncSche
 	conf := datadog.NewConfiguration()
 	conf.HTTPClient = httpClient
 
+	// If baseURL is provided, configure the official client to use it
+	if baseURL != "" {
+		conf.Servers = datadog.ServerConfigurations{
+			{
+				URL: baseURL,
+			},
+		}
+	}
+
 	// Create REST client for custom endpoints
-	restClient, err := client.NewDatadogRestClient(ctx, site, apiKey, appKey)
+	restClient, err := client.NewDatadogRestClient(ctx, site, apiKey, appKey, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create REST client: %w", err)
 	}
@@ -148,6 +158,7 @@ func New(ctx context.Context, site, apiKey, appKey string, syncSecrets, syncSche
 		site:          site,
 		apiKey:        apiKey,
 		appKey:        appKey,
+		baseURL:       baseURL,
 		client:        officialClient,
 		wrapper:       wrapper,
 		syncSecrets:   syncSecrets,


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-datadog/main.go,pkg/client/rest_client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-datadog --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.