### PR TITLE
Remove screenshots from connector doc

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -46,7 +46,7 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
 
 <Steps>
   <Step>
-  Log into Datadog account and navigate to **User Account** > **Organizational Settings**.
+  Log into your Datadog account and navigate to **User Account** > **Organizational Settings**.
   </Step>
   <Step>
   Click **API Keys** and then click **+ New Key**.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -38,11 +38,7 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
 
 <Steps>
   <Step>
-  Navigate to the Datadog login screen and make a note of your Datadog site:
-
-  <Frame>
-  <img src="/images/product/assets/datadog-2.png" alt="" />
-  </Frame>
+  Navigate to the Datadog login screen and make a note of your Datadog site. Common Datadog sites include "US1", "EU1", and "AP1". 
   </Step>
 </Steps>
 
@@ -50,14 +46,11 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
 
 <Steps>
   <Step>
-  Log into Datadog account and click **User Account** > **Organizational Settings**.
+  Log into Datadog account and navigate to **User Account** > **Organizational Settings**.
   </Step>
   <Step>
   Click **API Keys** and then click **+ New Key**.
 
-  <Frame>
-  <img src="/images/product/assets/datadog-6.png" alt="" />
-  </Frame>
   </Step>
   <Step>
   Enter a name for your new key, such as "ConductorOne", and click **Create Key**.
@@ -65,9 +58,6 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
   <Step>
   Copy and save the newly created API key.
 
-  <Frame>
-  <img src="/images/product/assets/datadog-9.png" alt="" />
-  </Frame>
   </Step>
 </Steps>
 
@@ -79,20 +69,12 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
   </Step>
   <Step>
   Click **Application Keys** and then click **+ New Key**.
-
-  <Frame>
-  <img src="/images/product/assets/datadog-3.png" alt="" />
-  </Frame>
   </Step>
   <Step>
   Enter a name for your new key, such as "ConductorOne", and click **Create Key**.
   </Step>
   <Step>
   Copy and save the newly created application key.
-
-  <Frame>
-  <img src="/images/product/assets/datadog-5.png" alt="" />
-  </Frame>
   </Step>
 </Steps>
 


### PR DESCRIPTION
As part of connector repo migration project, remove screenshots from connector docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced image frames with inline text descriptions across connector setup steps for clearer, more accessible guidance.
  * Clarified navigation and wording in the API key and application key creation flows, including common site names and improved step prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->