### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -78,7 +78,7 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Datadog connector
 
@@ -141,7 +141,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Datadog connector is now pulling access data into C1.
+**Done.** Your Datadog connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -265,7 +265,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Datadog connector is now pulling access data into C1.
+**Done.** Your Datadog connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.