### PR TITLE
Match Site config field to c1 builtin connector options

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -99,6 +99,14 @@
       "isRequired": true,
       "stringField": {
         "rules": {
+          "in": [
+            "datadoghq.com",
+            "us3.datadoghq.com",
+            "us5.datadoghq.com",
+            "datadoghq.eu",
+            "ddog-gov.com",
+            "ap1.datadoghq.com"
+          ],
           "isRequired": true
         }
       }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -48,7 +48,7 @@ If your user has a custom Datadog role, make sure it includes the **User App Key
 
 <Steps>
   <Step>
-  Navigate to the Datadog login screen and make a note of your Datadog site. Common Datadog sites include "US1", "EU1", and "AP1". 
+  Navigate to the Datadog login screen and make a note of your Datadog site. Valid Datadog sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `datadoghq.eu`, `ddog-gov.com`, and `ap1.datadoghq.com`.
   </Step>
 </Steps>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,8 +5,16 @@ import (
 )
 
 var (
-	Site = field.StringField(
+	Site = field.SelectField(
 		"site",
+		[]string{
+			"datadoghq.com",
+			"us3.datadoghq.com",
+			"us5.datadoghq.com",
+			"datadoghq.eu",
+			"ddog-gov.com",
+			"ap1.datadoghq.com",
+		},
 		field.WithDescription("Part of your Datadog website URL, e.g. datadoghq.com in https://app.datadoghq.com."),
 		field.WithRequired(true),
 		field.WithDisplayName("Site"),


### PR DESCRIPTION
## Summary
- Change the `site` config field from a plain string field to a `field.SelectField` restricted to the same options defined in c1's `pkg/builtin_connectors/datadog.go` (datadoghq.com, us3.datadoghq.com, us5.datadoghq.com, datadoghq.eu, ddog-gov.com, ap1.datadoghq.com), keeping the connector config schema in sync with c1's expected type/options.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Verify `--help` / schema output shows `site` as a select with the expected options