### PR TITLE
Wrap official Datadog client errors with gRPC status codes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -75,7 +75,7 @@ func (w *DatadogClient) CreateUser(ctx context.Context, req datadogV2.UserCreate
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("create user", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -98,7 +98,7 @@ func (w *DatadogClient) ListUsers(ctx context.Context, params *datadogV2.ListUse
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("list users", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -128,7 +128,7 @@ func (w *DatadogClient) ListTeams(ctx context.Context, params *datadogV2.ListTea
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("list teams", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -151,7 +151,7 @@ func (w *DatadogClient) ListRoles(ctx context.Context, params *datadogV2.ListRol
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("list roles", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -174,7 +174,7 @@ func (w *DatadogClient) ListAPIKeys(ctx context.Context, params *datadogV2.ListA
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("list API keys", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -189,7 +189,10 @@ func (w *DatadogClient) ListRoleUsers(ctx context.Context, roleId string, params
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return &users, err
+	if err != nil {
+		return &users, wrapOfficialClientError("list role users", httpRes, err)
+	}
+	return &users, nil
 }
 
 // AddUserToRole adds a user to a role and automatically handles HTTP response body closing.
@@ -200,7 +203,10 @@ func (w *DatadogClient) AddUserToRole(ctx context.Context, roleId string, body d
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return &resp, err
+	if err != nil {
+		return &resp, wrapOfficialClientError("add user to role", httpRes, err)
+	}
+	return &resp, nil
 }
 
 // RemoveUserFromRole removes a user from a role and automatically handles HTTP response body closing.
@@ -214,7 +220,10 @@ func (w *DatadogClient) RemoveUserFromRole(ctx context.Context, roleId string, b
 	if err != nil && httpRes != nil && httpRes.StatusCode == http.StatusNotFound {
 		return &resp, errors.Join(ErrNotFound, err)
 	}
-	return &resp, err
+	if err != nil {
+		return &resp, wrapOfficialClientError("remove user from role", httpRes, err)
+	}
+	return &resp, nil
 }
 
 // GetTeamMemberships gets team memberships and automatically handles HTTP response body closing.
@@ -225,7 +234,10 @@ func (w *DatadogClient) GetTeamMemberships(ctx context.Context, teamId string, p
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return &memberships, err
+	if err != nil {
+		return &memberships, wrapOfficialClientError("get team memberships", httpRes, err)
+	}
+	return &memberships, nil
 }
 
 // GetUser gets a user by ID and automatically handles HTTP response body closing.
@@ -239,7 +251,10 @@ func (w *DatadogClient) GetUser(ctx context.Context, userId string) (*datadogV2.
 	if err != nil && httpRes != nil && httpRes.StatusCode == http.StatusNotFound {
 		return &user, errors.Join(ErrNotFound, err)
 	}
-	return &user, err
+	if err != nil {
+		return &user, wrapOfficialClientError("get user", httpRes, err)
+	}
+	return &user, nil
 }
 
 // CreateTeamMembership creates a team membership and automatically handles HTTP response body closing.
@@ -250,7 +265,10 @@ func (w *DatadogClient) CreateTeamMembership(ctx context.Context, teamId string,
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return &resp, err
+	if err != nil {
+		return &resp, wrapOfficialClientError("create team membership", httpRes, err)
+	}
+	return &resp, nil
 }
 
 // DeleteTeamMembership deletes a team membership and automatically handles HTTP response body closing.
@@ -264,7 +282,10 @@ func (w *DatadogClient) DeleteTeamMembership(ctx context.Context, teamId string,
 	if err != nil && httpRes != nil && httpRes.StatusCode == http.StatusNotFound {
 		return errors.Join(ErrNotFound, err)
 	}
-	return err
+	if err != nil {
+		return wrapOfficialClientError("delete team membership", httpRes, err)
+	}
+	return nil
 }
 
 // ValidateCredentials validates API credentials and automatically handles HTTP response body closing.
@@ -275,7 +296,10 @@ func (w *DatadogClient) ValidateCredentials(ctx context.Context) (*datadogV1.Aut
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return &resp, err
+	if err != nil {
+		return &resp, wrapOfficialClientError("validate credentials", httpRes, err)
+	}
+	return &resp, nil
 }
 
 // UpdateUser updates a Datadog user. PATCH /api/v2/users/{user_id}. Requires the
@@ -288,7 +312,7 @@ func (w *DatadogClient) UpdateUser(ctx context.Context, userId string, body data
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, wrapOfficialClientError("update user", httpRes, err)
 	}
 	return &resp, nil
 }
@@ -302,5 +326,8 @@ func (w *DatadogClient) DisableUser(ctx context.Context, userId string) error {
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-	return err
+	if err != nil {
+		return wrapOfficialClientError("disable user", httpRes, err)
+	}
+	return nil
 }

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"google.golang.org/grpc/codes"
+)
+
+// wrapOfficialClientError maps an error returned by the official Datadog SDK
+// (datadog-api-client-go) to a gRPC-coded error, mirroring how uhttp.BaseHttpClient
+// classifies HTTP responses for baton-sdk's sync/retry engine. The official client
+// bypasses uhttp entirely, so without this mapping errors from ListUsers, ListTeams,
+// ListRoles, etc. carry no gRPC code and the sync engine cannot tell a transient
+// rate-limit (429) from a permanent failure, so a sync fails instead of retrying.
+func wrapOfficialClientError(operation string, httpRes *http.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if httpRes == nil {
+		// No response means a network-level failure (timeout, connection reset, etc.);
+		// treat it the same way uhttp does for transient errors so the sync can retry.
+		return uhttp.WrapErrors(codes.Unavailable, fmt.Sprintf("baton-datadog: %s: network or connection error", operation), err)
+	}
+
+	// Use the SDK's own HTTP-status-to-gRPC-code mapping (the same mapping
+	// uhttp.BaseHttpClient.Do applies) so both HTTP paths in this connector are
+	// classified consistently. Notably, this maps 429 to codes.Unavailable, not
+	// codes.ResourceExhausted, which is what the sync engine's retry loop checks for.
+	code := uhttp.GrpcCodeFromHTTPStatus(httpRes.StatusCode)
+	return uhttp.WrapErrorsWithRateLimitInfo(code, httpRes, err)
+}


### PR DESCRIPTION
## Summary

- Adds `wrapOfficialClientError` in `pkg/client/errors.go`, which maps errors from the official Datadog SDK client (`datadog-api-client-go`) onto gRPC status codes using the same mapping `uhttp.BaseHttpClient` already applies to the custom REST client path (`uhttp.GrpcCodeFromHTTPStatus` + `uhttp.WrapErrorsWithRateLimitInfo`).
- Routes every official-client call site in `pkg/client/client.go` (ListUsers, ListTeams, ListRoles, ListAPIKeys, GetUser, CreateUser, UpdateUser, DisableUser, role/team membership methods, ValidateCredentials) through this helper, preserving the existing `ErrNotFound` handling for 404s.

## Root cause

The official Datadog SDK client is used for all the high-volume sync endpoints and bypasses baton-sdk's `uhttp` layer entirely. Its errors carried no gRPC code, so baton-sdk's sync engine couldn't distinguish a transient rate-limit response (429) from a permanent failure — it failed the sync instead of retrying.

This connector already has an open PR (#31, bot-authored) that enables the official Datadog client's internal retry configuration for CXH-2000. That's a useful complement, but it only retries within the official client's own request loop — it doesn't add gRPC codes, so once its retries are exhausted (or for errors from other call sites this fix also covers) the sync would still fail hard with no code for baton-sdk's own retry/backoff to act on. This PR fixes the underlying gap so error classification is consistent across both HTTP paths in the connector, matching the pattern used in other connectors (baton-zendesk, baton-jumpcloud) for third-party SDKs that bypass `uhttp`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (27 tests, 5 packages)

Fixes: CXH-2000