### PR TITLE
CXH-2184: disable_user no longer reports success on GetUser 404

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -9,7 +9,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-datadog/pkg/client"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -161,9 +160,6 @@ func (d *Datadog) disableUser(ctx context.Context, args *structpb.Struct) (*stru
 
 	user, err := d.wrapper.GetUser(ctx, userID)
 	if err != nil {
-		if client.IsNotFound(err) {
-			return actions.NewReturnValues(true), nil, nil
-		}
 		return nil, nil, fmt.Errorf("baton-datadog: failed to look up user %s: %w", userID, err)
 	}
 	if user.GetData().Attributes.GetDisabled() {

--- a/pkg/connector/actions_test.go
+++ b/pkg/connector/actions_test.go
@@ -2,10 +2,15 @@ package connector
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/conductorone/baton-datadog/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // schemaByName indexes action schemas by their action name.
@@ -82,5 +87,35 @@ func TestLifecycleActionsAreGlobal(t *testing.T) {
 	}
 	if _, ok := userByName[ActionDisableUser]; ok {
 		t.Errorf("%q should not be registered as a user-scoped action", ActionDisableUser)
+	}
+}
+
+// TestDisableUserNotFoundFails verifies that a GetUser 404 during disable_user
+// propagates as an error rather than reporting success, matching enable_user's
+// behavior for the same input. See CXH-2184: previously any 404 from GetUser
+// (not only a truly-deleted user) short-circuited to success:true without ever
+// issuing the DELETE that performs the soft-disable.
+func TestDisableUserNotFoundFails(t *testing.T) {
+	const userID = "deadbeef-0000-4000-8000-000000000000"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":["Not found"]}`))
+	}))
+	defer server.Close()
+
+	cfg := datadog.NewConfiguration()
+	cfg.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	wrapper := client.NewDatadogClient(nil, datadog.NewAPIClient(cfg), "example.com", "api-key", "app-key")
+	d := &Datadog{wrapper: wrapper}
+
+	args, err := structpb.NewStruct(map[string]interface{}{"user_id": userID})
+	if err != nil {
+		t.Fatalf("failed to build args: %v", err)
+	}
+
+	_, _, err = d.disableUser(context.Background(), args)
+	if err == nil {
+		t.Fatal("disableUser returned nil error for a 404 GetUser response, want an error")
 	}
 }


### PR DESCRIPTION
## Summary
- `disable_user` looked the target user up before deprovisioning and treated *any* 404 from `GetUser` as success, returning `success: true` without ever issuing the `DELETE` that performs Datadog's soft-disable. This masked wrong ids, users from a different org, and stale resource ids as completed deprovisions.
- `enable_user` has no equivalent guard and fails loudly on the same input — the two actions disagreed on how an unresolvable target is reported.
- Removed the not-found special-case in `disableUser` so a `GetUser` error (404 or otherwise) now propagates as an error, matching `enable_user`'s behavior.

Fixes [CXH-2184](https://linear.app/ductone/issue/CXH-2184/baton-datadog-disable-user-reports-success-when-the-target-user-is-not).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (30 passed)
- [x] Added `TestDisableUserNotFoundFails` — spins up an `httptest.Server` returning 404 for `GetUser` and asserts `disableUser` now returns an error instead of `success: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)