### PR TITLE
Add Datadog credential issuance

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -179,6 +179,42 @@ func (w *DatadogClient) ListAPIKeys(ctx context.Context, params *datadogV2.ListA
 	return &resp, nil
 }
 
+type IssuedAPIKey struct {
+	ID     string
+	Secret string
+}
+
+func (w *DatadogClient) CreateAPIKey(ctx context.Context, name string) (*IssuedAPIKey, error) {
+	ctx = w.withAuthContext(ctx)
+	api := datadogV2.NewKeyManagementApi(w.officialClient)
+	attrs := *datadogV2.NewAPIKeyCreateAttributes(name)
+	data := *datadogV2.NewAPIKeyCreateData(attrs, datadogV2.APIKEYSTYPE_API_KEYS)
+	response, httpRes, err := api.CreateAPIKey(ctx, *datadogV2.NewAPIKeyCreateRequest(data))
+	if httpRes != nil {
+		defer httpRes.Body.Close()
+	}
+	if err != nil {
+		return nil, wrapOfficialClientError("create API key", httpRes, err)
+	}
+	if response.Data.Id == nil || response.Data.Attributes == nil || response.Data.Attributes.Key == nil || *response.Data.Attributes.Key == "" {
+		return nil, fmt.Errorf("create API key response omitted id or key")
+	}
+	return &IssuedAPIKey{ID: *response.Data.Id, Secret: *response.Data.Attributes.Key}, nil
+}
+
+func (w *DatadogClient) DeleteAPIKey(ctx context.Context, id string) error {
+	ctx = w.withAuthContext(ctx)
+	api := datadogV2.NewKeyManagementApi(w.officialClient)
+	httpRes, err := api.DeleteAPIKey(ctx, id)
+	if httpRes != nil {
+		defer httpRes.Body.Close()
+	}
+	if err != nil {
+		return wrapOfficialClientError("delete API key", httpRes, err)
+	}
+	return nil
+}
+
 // Wrapper methods that handle HTTP response body closing automatically
 
 // ListRoleUsers lists users for a specific role and automatically handles HTTP response body closing.

--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/conductorone/baton-datadog/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -20,6 +21,17 @@ type apiTokenBuilder struct {
 }
 
 var _ connectorbuilder.ResourceSyncerV2 = &apiTokenBuilder{}
+var _ connectorbuilder.ResourceDeleterV2Limited = &apiTokenBuilder{}
+
+func (o *apiTokenBuilder) Delete(ctx context.Context, resourceID *v2.ResourceId, _ *v2.ResourceId) (annotations.Annotations, error) {
+	if resourceID == nil || resourceID.GetResource() == "" {
+		return nil, fmt.Errorf("baton-datadog: API key id is required")
+	}
+	if err := o.wrapper.DeleteAPIKey(ctx, resourceID.GetResource()); err != nil {
+		return nil, fmt.Errorf("baton-datadog: delete API key: %w", err)
+	}
+	return nil, nil
+}
 
 func (o *apiTokenBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	// API Token secrets do not have entitlements

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -34,8 +34,12 @@ type Datadog struct {
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Datadog) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	userSyncer := connectorbuilder.ResourceSyncerV2(newUserBuilder(d.wrapper))
+	if d.SyncSecrets {
+		userSyncer = newCredentialUserBuilder(d.wrapper)
+	}
 	resourceSyncers := []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.wrapper),
+		userSyncer,
 		newTeamBuilder(d.wrapper),
 		newRoleBuilder(d.wrapper),
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -19,6 +19,41 @@ type userBuilder struct {
 	wrapper      *client.DatadogClient
 }
 
+type credentialUserBuilder struct{ *userBuilder }
+
+func newCredentialUserBuilder(wrapper *client.DatadogClient) *credentialUserBuilder {
+	return &credentialUserBuilder{userBuilder: newUserBuilder(wrapper)}
+}
+
+func (u *credentialUserBuilder) IssueCapabilityDetails(context.Context) (*v2.CredentialDetailsCredentialIssue, annotations.Annotations, error) {
+	return v2.CredentialDetailsCredentialIssue_builder{
+		Options: []*v2.CredentialIssueOptionDescriptor{v2.CredentialIssueOptionDescriptor_builder{
+			Option:               v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_API_KEY,
+			ResourceMode:         v2.CredentialResourceMode_CREDENTIAL_RESOURCE_MODE_DISCOVERABLE,
+			SecretResourceTypeId: apiTokenResourceType.Id,
+		}.Build()},
+		PreferredOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_API_KEY,
+	}.Build(), nil, nil
+}
+
+func (u *credentialUserBuilder) Issue(ctx context.Context, input *connectorbuilder.CredentialIssueInput) (*connectorbuilder.CredentialIssueOutput, error) {
+	if input == nil || input.IdentityID == nil || input.IdentityID.GetResourceType() != userResourceType.Id {
+		return nil, fmt.Errorf("baton-datadog: a Datadog user identity is required")
+	}
+	name := "c1-" + input.RequestID
+	key, err := u.wrapper.CreateAPIKey(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("baton-datadog: create API key: %w", err)
+	}
+	secret, err := rs.NewSecretResource(name, apiTokenResourceType, key.ID,
+		[]rs.SecretTraitOption{rs.WithSecretCreatedByID(input.IdentityID), rs.WithSecretIdentityID(input.IdentityID), rs.WithSecretType(v2.SecretTrait_CREDENTIAL_TYPE_STATIC_SECRET), rs.WithSecretDetail("datadog.api_key")},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &connectorbuilder.CredentialIssueOutput{Secret: secret, PlaintextData: []*v2.PlaintextData{v2.PlaintextData_builder{Name: "api_key", Bytes: []byte(key.Secret)}.Build()}, ResourceMode: v2.CredentialResourceMode_CREDENTIAL_RESOURCE_MODE_DISCOVERABLE}, nil
+}
+
 var _ connectorbuilder.ResourceSyncerV2 = &userBuilder{}
 var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
 var _ connectorbuilder.ResourceActionProvider = &userBuilder{}


### PR DESCRIPTION
## Summary
- issue deterministic Datadog API keys
- add API-key revocation through the V2 key-management API
- advertise delete-only credential issuance when secret sync is enabled

## Verification
- 
- 

Live tenant verification is pending Datadog credentials.